### PR TITLE
Add support for inherent signature.

### DIFF
--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -165,7 +165,7 @@ class InhBase():
         self.uncollected = kwargs
         
 
-@TestInhReg.register_module(inherent=True)
+@TestInhReg.register_module(inherit=True)
 class InhChild1(InhBase):
     def __init__(self, c: int, d: int, **kwargs):
         super().__init__(**kwargs)
@@ -191,7 +191,7 @@ def test_superclass_registry():
     assert "InhChild1" in TestInhReg
     assert "InhChildNotDefined" not in TestInhReg
 
-    # when inherent is set True, the module will look back to its super class for areas
+    # when inherit is set True, the module will look back to its super class for areas
     config = TypeDef.load(
         InhRegCfg, dict(m=dict(type="InhChild1", a=1, b=2, c=3, d=4))
     )
@@ -201,14 +201,14 @@ def test_superclass_registry():
     assert config.m.build(e=5).uncollected['e'] == 5
 
     with pytest.raises(ValidationError):
-        # when inherent is set False (default), all the keys must be specifed in the param list of __init__
+        # when inherit is set False (default), all the keys must be specifed in the param list of __init__
         config = TypeDef.load(
             InhRegCfg, dict(m=dict(type="InhChild2", a=1, b=2, c=3, d=4))
         )
 
     with pytest.raises(ValidationError):
-        # when inherent is set True, use of positional arguments is banned to remove possible confusions
-        @TestInhReg.register_module(inherent=True)
+        # when inherit is set True, use of positional arguments is banned to remove possible confusions
+        @TestInhReg.register_module(inherit=True)
         class InhChildwithPosArgs(InhBase):
             def __init__(self, c: int, d: int, *args, **kwargs):
                 super().__init__(**kwargs)
@@ -221,7 +221,7 @@ def test_superclass_registry():
 
     TestInhReg.unregister_module("InhChildwithPosArgs")
 
-    # won't raise TypeError with *args when inherent is set False (default) TODO: should this use also be banned?
+    # won't raise TypeError with *args when inherit is set False (default) TODO: should this use also be banned?
     @TestInhReg.register_module()
     class InhChildwithPosArgs(InhBase):
         def __init__(self, a: int, b: int, c: int, d: int, *args, **kwargs):

--- a/utilsd/config/registry.py
+++ b/utilsd/config/registry.py
@@ -142,7 +142,6 @@ class SubclassConfig(Generic[T], metaclass=DataclassType):
 def dataclass_from_class(cls):
     """Create a configurable dataclass for a class
     based on its ``__init__`` signature.
-    FIXME: Building dataclass from both the init_signature of the class, but also its super classes
     """
     class_name = cls.__name__ + 'Config'
     fields = [

--- a/utilsd/config/registry.py
+++ b/utilsd/config/registry.py
@@ -167,6 +167,7 @@ def dataclass_from_class(cls, *, inherent_signature=False):
         if param.kind == param.VAR_POSITIONAL:
             if inherent_signature:
                 # Prohibit uncollected positional varibles
+                # TODO: should positional params be banned from all use cases? 
                 raise TypeError(f'Use of positional params `*arg` in "{cls}" is prehibitted. Try to use `**kwargs` instead to avoid possible confusion.')
             continue
         if param.kind == param.VAR_KEYWORD:
@@ -221,6 +222,7 @@ def dataclass_from_class(cls, *, inherent_signature=False):
         result = {f.name: getattr(self, f.name) for f in dataclasses.fields(self)}
         for k in kwargs:
             # silently overwrite the arguments with given ones.
+            # FIXME: add type check when building?
             result[k] = kwargs[k]
         try:
             return self._type(**result)

--- a/utilsd/config/registry.py
+++ b/utilsd/config/registry.py
@@ -139,7 +139,7 @@ class SubclassConfig(Generic[T], metaclass=DataclassType):
     """
 
 
-def dataclass_from_class(cls):
+def dataclass_from_class(cls, *, inherent_signature=True):
     """Create a configurable dataclass for a class
     based on its ``__init__`` signature.
     """
@@ -162,7 +162,8 @@ def dataclass_from_class(cls):
             raise TypeError(f'Use of positional params `*arg` in "{cls}" is prehibitted. Try to use `**kwargs` instead to avoid possible confusion.')
         if param.kind == param.VAR_KEYWORD:
             # Expand __init__ of the super classes for signitures
-            expand_super = True
+            if inherent_signature:
+                expand_super = True
             continue
 
         # TODO: fix type annotation for dependency injection

--- a/utilsd/config/type_def.py
+++ b/utilsd/config/type_def.py
@@ -584,8 +584,8 @@ class RegistryConfigDef(DataclassDef):
             raise TypeError(f'Expect a dict with key "type", but found {type(plain)}: {plain}')
         # copy the raw object to prevent unexpected modification
         plain = copy.copy(plain)
-        type_, inherent = self.registry.get_module_with_inherent(plain.pop('type'))
-        dataclass = dataclass_from_class(type_, inherent_signature=inherent)
+        type_, inherit = self.registry.get_module_with_inherit(plain.pop('type'))
+        dataclass = dataclass_from_class(type_, inherit_signature=inherit)
         return super().from_plain(plain, ctx, type_=dataclass)
 
     def to_plain(self, obj, ctx):

--- a/utilsd/config/type_def.py
+++ b/utilsd/config/type_def.py
@@ -584,9 +584,8 @@ class RegistryConfigDef(DataclassDef):
             raise TypeError(f'Expect a dict with key "type", but found {type(plain)}: {plain}')
         # copy the raw object to prevent unexpected modification
         plain = copy.copy(plain)
-
-        type_ = self.registry.get(plain.pop('type'))
-        dataclass = dataclass_from_class(type_)
+        type_, inherent = self.registry.get_module_with_inherent(plain.pop('type'))
+        dataclass = dataclass_from_class(type_, inherent_signature=inherent)
         return super().from_plain(plain, ctx, type_=dataclass)
 
     def to_plain(self, obj, ctx):


### PR DESCRIPTION
The dataclass will now look for its base classes for signature when **kwargs is included in its construction method.